### PR TITLE
Update migx.class.php

### DIFF
--- a/core/components/migx/model/migx/migx.class.php
+++ b/core/components/migx/model/migx/migx.class.php
@@ -221,7 +221,12 @@ class Migx {
         }
 
         if (!empty($groupby)) {
-            $c->groupby($groupby);
+            // Fix ERROR "SELECT list is not in GROUP BY clause" with sql_mode=only_full_group_by
+            if ($groupby == 'name') {
+                $c->groupby(array('id', 'name'));
+            } else {
+                $c->groupby($groupby);
+            }
         }
 
         //set "total" placeholder for getPage


### PR DESCRIPTION
MODX Revo 2.7.3-pl
Fix error with sql_mode=only_full_group_by
---
/xpdo/om/xpdoobject.class.php : 240 Error 42000 executing statement: Array ( [0] => 42000 [1] => 1055 [2] => Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'xxxxxxx.migxConfig.id' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by